### PR TITLE
datapackage.json pataisymas

### DIFF
--- a/datapackage.json
+++ b/datapackage.json
@@ -112,8 +112,11 @@
         ]
       },
       "url": "http://gobetween.oklabs.org/pipe/https%3A%2F%2Fraw.githubusercontent.com%2Fvilnius%2Ftransportas-velavimai%2Fmaster%2Frpt3%2Flatest.tsv",
-      "format": "TSV",
+      "format": "csv",
       "mediatype": "text/csv",
+      "dialect": {
+          "delimiter": "\t"
+      },
       "bytes": 0
     }
   ]


### PR DESCRIPTION
Pataisiau `datapackage.json`, išbandžiau su Python `datapackage` biblioteka, veikia. Bet su DataPackage viewer vis tiek neveikia, radau, kad jie nepalaiko `dialekt` parametro, pranešiau apie klaidą [1], gal pasitaisys.

[1] https://github.com/frictionlessdata/datapackage-render-js/issues/16
